### PR TITLE
fix: correct CI template bugs for GitLab and GitHub Actions

### DIFF
--- a/templates/ci/github/workflows/ci.yml.tpl
+++ b/templates/ci/github/workflows/ci.yml.tpl
@@ -10,14 +10,16 @@ permissions:
   contents: read
   packages: write
 
-env:
-  CI_IMAGE: ghcr.io/${{ github.repository }}/ci:php<?= $phpVersion ?>
-
-
 jobs:
   build-image:
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
     steps:
+      - name: Set image name
+        id: meta
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}/ci:php<?= $phpVersion ?>" >> $GITHUB_OUTPUT
+
       - uses: actions/checkout@v4
 
       - name: Log in to GHCR
@@ -36,7 +38,7 @@ jobs:
           context: .
           file: .github/ci/Dockerfile
           push: true
-          tags: ${{ env.CI_IMAGE }}
+          tags: ${{ steps.meta.outputs.image }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -44,7 +46,7 @@ jobs:
     needs: [build-image]
     runs-on: ubuntu-latest
     container:
-      image: ${{ env.CI_IMAGE }}
+      image: ${{ needs.build-image.outputs.image }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -95,7 +97,7 @@ jobs:
     needs: [build-image, build]
     runs-on: ubuntu-latest
     container:
-      image: ${{ env.CI_IMAGE }}
+      image: ${{ needs.build-image.outputs.image }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -122,7 +124,7 @@ jobs:
     needs: [build-image, build]
     runs-on: ubuntu-latest
     container:
-      image: ${{ env.CI_IMAGE }}
+      image: ${{ needs.build-image.outputs.image }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -164,11 +166,11 @@ jobs:
 <?php if ($databaseType === 'postgresql'): ?>
         options: --health-cmd pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
 <?php else: ?>
-        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping -h 127.0.0.1 -u root -p<?= $databaseEnvVars['MYSQL_ROOT_PASSWORD'] ?> --silent" --health-interval=5s --health-timeout=5s --health-retries=10
 <?php endif; ?>
 <?php endif; ?>
     container:
-      image: ${{ env.CI_IMAGE }}
+      image: ${{ needs.build-image.outputs.image }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/ci/gitlab-ci.yml.tpl
+++ b/templates/ci/gitlab-ci.yml.tpl
@@ -42,19 +42,15 @@ variables:
 
 build:image:
   stage: .pre
-  image:
-    name: gcr.io/kaniko-project/executor:v1.23.2-debug
-    entrypoint: [""]
+  image: docker:27
+  services:
+    - docker:27-dind
+  variables:
+    DOCKER_TLS_CERTDIR: "/certs"
   script:
-    - mkdir -p /kaniko/.docker
-    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"auth\":\"$(printf '%s:%s' "$CI_REGISTRY_USER" "$CI_REGISTRY_PASSWORD" | base64)\"}}}" > /kaniko/.docker/config.json
-    - >-
-      /kaniko/executor
-      --context $CI_PROJECT_DIR
-      --dockerfile $CI_PROJECT_DIR/.gitlab/ci/Dockerfile
-      --destination $CI_IMAGE
-      --cache=true
-      --cache-repo $CI_REGISTRY_IMAGE/ci/cache
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+    - docker build -t $CI_IMAGE -f .gitlab/ci/Dockerfile .
+    - docker push $CI_IMAGE
   rules:
     - changes:
         - .gitlab/ci/Dockerfile

--- a/tests/Generator/GitHubActionsGeneratorTest.php
+++ b/tests/Generator/GitHubActionsGeneratorTest.php
@@ -107,7 +107,7 @@ final class GitHubActionsGeneratorTest extends TestCase
 
         $ci = $files['.github/workflows/ci.yml'];
         self::assertStringContainsString('container:', $ci);
-        self::assertStringContainsString('image: ${{ env.CI_IMAGE }}', $ci);
+        self::assertStringContainsString('image: ${{ needs.build-image.outputs.image }}', $ci);
     }
 
     public function testCiWithDatabaseUsesDatabaseHostname(): void
@@ -172,7 +172,7 @@ final class GitHubActionsGeneratorTest extends TestCase
 
         $files = $this->generator->generate($config);
 
-        self::assertStringContainsString('ghcr.io/${{ github.repository }}/ci:php8.4', $files['.github/workflows/ci.yml']);
+        self::assertStringContainsString('ghcr.io/${GITHUB_REPOSITORY,,}/ci:php8.4', $files['.github/workflows/ci.yml']);
     }
 
     public function testCiJobsNeedBuildImage(): void

--- a/tests/Generator/GitLabCiGeneratorTest.php
+++ b/tests/Generator/GitLabCiGeneratorTest.php
@@ -115,7 +115,8 @@ final class GitLabCiGeneratorTest extends TestCase
 
         $ci = $files['.gitlab-ci.yml'];
         self::assertStringContainsString('build:image:', $ci);
-        self::assertStringContainsString('kaniko', $ci);
+        self::assertStringContainsString('docker:27', $ci);
+        self::assertStringContainsString('docker login -u gitlab-ci-token -p $CI_JOB_TOKEN', $ci);
         self::assertStringContainsString('$CI_IMAGE', $ci);
     }
 


### PR DESCRIPTION
## Summary

- **GitLab CI**: Replace Kaniko with Docker-in-Docker (`docker:27` + `docker:27-dind`) for image builds, using `CI_JOB_TOKEN` auth instead of fragile base64-encoded `CI_REGISTRY_PASSWORD` credentials
- **GitHub Actions**: Fix `container.image` reference — `env.CI_IMAGE` is not supported in `container.image` context (only `github`, `needs`, `vars`, `secrets` are). Use job `outputs` with `${GITHUB_REPOSITORY,,}` for lowercase image name instead
- **GitHub Actions**: Fix MySQL/MariaDB healthcheck — replace `healthcheck.sh --connect --innodb_initialized` (which exhausts retries during init) with `mysqladmin ping` with shorter interval and more retries

## Test plan

- [x] All 168 existing unit tests pass
- [x] Generate a test project with GitLab CI + MySQL and verify the output
- [x] Generate a test project with GitHub Actions + MySQL and verify the output
- [x] Generate a test project with GitHub Actions + PostgreSQL and verify the output