### PR TITLE
fix: replace addCommand() with add() for symfony/console 7.x compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        symfony-version: ['^7.0', '^8.0']
+    name: test (Symfony ${{ matrix.symfony-version }})
     steps:
       - uses: actions/checkout@v4
 
@@ -91,8 +95,15 @@ jobs:
           php-version: '8.4'
           extensions: intl, zip
 
+      - name: Require Symfony ${{ matrix.symfony-version }}
+        run: |
+          composer require \
+            symfony/console:${{ matrix.symfony-version }} \
+            symfony/filesystem:${{ matrix.symfony-version }} \
+            --no-update --no-interaction
+
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: composer update --prefer-dist --no-progress
 
       - name: Run tests
         run: vendor/bin/phpunit --testdox

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,8 @@ parameters:
     paths:
         - src
         - tests
+    bootstrapFiles:
+        - vendor/autoload.php
     excludePaths:
         - tests/bootstrap.php
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -25,9 +25,9 @@ final class Application extends BaseApplication
     {
         parent::__construct(self::NAME, self::VERSION);
 
-        $this->addCommand(new InitCommand());
-        $this->addCommand(new CiUpdateCommand());
-        $this->addCommand(new CiAddCommand());
+        $this->add(new InitCommand());
+        $this->add(new CiUpdateCommand());
+        $this->add(new CiAddCommand());
         $this->setDefaultCommand('init');
     }
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -24,10 +24,15 @@ final class Application extends BaseApplication
     public function __construct()
     {
         parent::__construct(self::NAME, self::VERSION);
-
-        $this->add(new InitCommand());
-        $this->add(new CiUpdateCommand());
-        $this->add(new CiAddCommand());
         $this->setDefaultCommand('init');
+    }
+
+    protected function getDefaultCommands(): array
+    {
+        return array_merge(parent::getDefaultCommands(), [
+            new InitCommand(),
+            new CiUpdateCommand(),
+            new CiAddCommand(),
+        ]);
     }
 }


### PR DESCRIPTION
## Problem

`Symfony\Component\Console\Application::addCommand()` does not exist in symfony/console 7.x. The available methods are `add()` (single command) and `addCommands()` (array). This causes a fatal error when running `vendor/bin/coding-standard init` in projects using symfony/console ^7.0.

## Fix

Replace `addCommand()` with `add()`, which is the correct method name and is compatible with both symfony/console ^7.0 and ^8.0.